### PR TITLE
Allow WebClient to be serialized and recreated without logging in again

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ with open(data.filename, 'wb') as f:
         if not chunk:
             break
         f.write(chunk)
+
+# Serialize and recreate WebClient without logging in again
+args = client.client_args
+del client
+client = WebClient(**client_args)
 ```
 
 ### Delete activities

--- a/README.md
+++ b/README.md
@@ -4,6 +4,31 @@ stravaweblib
 Provides all the functionality of the [stravalib](https://github.com/hozn/stravalib) package and
 extends it using web scraping.
 
+Authentication
+--------------
+In order to log into the website, the `WebClient` class either needs an email and password, or the
+[JWT](https://en.wikipedia.org/wiki/JSON_Web_Token) of an existing session. Strava stores this JWT
+in the `strava_remember_token` cookie.
+
+After the client has logged in, a JWT for the current session can be accessed via the `WebClient`'s
+`jwt` property. Storing this JWT (and the `access_token` from `stravalib`) allows for resuming the
+session without having to log in again. This can avoid rate limits and lockouts.
+
+Example:
+```python
+from stravaweblib import WebClient
+
+# Log in (requires API token and email/password for the site)
+client = WebClient(access_token=OAUTH_TOKEN, email=EMAIL, password=PASSWORD)
+
+# Store the current session's information
+jwt = client.jwt
+access_token = client.access_token
+
+# Create a new client that continues to use the previous web session
+client = WebClient(access_token=access_token, jwt=jwt)
+```
+
 Extra functionality
 -------------------
 
@@ -29,11 +54,6 @@ with open(data.filename, 'wb') as f:
         if not chunk:
             break
         f.write(chunk)
-
-# Serialize and recreate WebClient without logging in again
-args = client.client_args
-del client
-client = WebClient(**client_args)
 ```
 
 ### Delete activities


### PR DESCRIPTION
As described in https://github.com/pR0Ps/stravaweblib/issues/2#issuecomment-932356236 and previously used in 44565582f56c6bffe6c2554193fbedb7ef58768f, logging into the Strava web interface creates 3 cookies:

- `strava_remember_token` is a [JWT](https://en.wikipedia.org/wiki/JSON_Web_Token)
- `strava_remember_id` is necessary for the web interface to recognize the session, but it is redundant since it can be recreated from the unencrypted payload of  `strava_remember_token`
- `_strava4_session` is unnecessary, because the web interface will still recognize the session if it's deleted

We can our understanding of the Strava cookies, and the CSRF token, to make it possible to easily serialize and recreate the WebClient without repeating the login process or retaining the user's password:

```py
>> from stravaweblib.webclient import WebClient
>> client = WebClient(email='me@my.com', password='password', access_token='StravaAPIToken')
>> print(repr(client))
stravaweblib.webclient.WebClient(csrf={'authenticity_token': '<base64 string>'}, strava_remember_token='<base64 Java Web Token>', access_token='StravaAPIToken')
>> print(c.client_args)
{'csrf': {'authenticity_token': '<base64 string>'}, 'strava_remember_token': '<base64 Java Web Token>', 'access_token': 'StravaAPIToken'}
>> args = c.client_args
>> del client
>> client = WebClient(**args)
```

Among other things, caching the client_args and reusing them in this way can avoid rate-limiting/lockout, which will happen if you log into the Strava web interface too frequently,