### PR TITLE
Exporting Route Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,7 @@ data = client.get_activity_data(activity_id, fmt=DataFormat.ORIGINAL)
 
 # Save the activity data to disk using the server-provided filename
 with open(data.filename, 'wb') as f:
-    for chunk in data.content:
-        if not chunk:
-            break
-        f.write(chunk)
+    f.writelines(data.content)
 ```
 
 ### Delete activities
@@ -98,7 +95,7 @@ client.get_bike_components(bike_id)
 client.get_bike_components(bike_id, on_date=datetime.now())
 ```
 
-### Export Routes
+### Export routes
 Download route files as GPX or TCX.
 
 ```python
@@ -116,10 +113,7 @@ data = client.get_route_data(route_id, fmt=DataFormat.GPX)
 
 # Save the activity data to disk using the server-provided filename
 with open(data.filename, 'wb') as f:
-    for chunk in data.content:
-        if not chunk:
-            break
-        f.write(chunk)
+    f.writelines(data.content)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ client = WebClient(access_token=OAUTH_TOKEN, email=EMAIL, password=PASSWORD)
 
 # Get the first activity id (uses the normal stravalib API)
 activities = client.get_activities()
-activity_id = activities[0].id
+activity_id = activities.next().id
 
 # Get the filename and data stream for the activity data
 data = client.get_activity_data(activity_id, fmt=DataFormat.ORIGINAL)
@@ -68,7 +68,7 @@ client = WebClient(access_token=OAUTH_TOKEN, email=EMAIL, password=PASSWORD)
 
 # Get the first activity id (uses the normal stravalib API)
 activities = client.get_activities()
-activity_id = activities[0].id
+activity_id = activities.next().id
 
 # Delete the activity
 client.delete_activity(activity_id)
@@ -89,7 +89,7 @@ athlete = client.get_athlete()
 bikes = athlete.bikes
 
 # Get the id of the first bike
-bike_id = bikes[0].id
+bike_id = bikes.next().id
 
 # Get all components of the first bike (past and present)
 client.get_bike_components(bike_id)
@@ -97,6 +97,31 @@ client.get_bike_components(bike_id)
 # Get the current components on the first bike
 client.get_bike_components(bike_id, on_date=datetime.now())
 ```
+
+### Export Routes
+Download route files as GPX or TCX.
+
+```python
+from stravaweblib import WebClient, DataFormat
+
+# Log in (requires API token and email/password for the site)
+client = WebClient(access_token=OAUTH_TOKEN, email=EMAIL, password=PASSWORD)
+
+# Get the first route id (uses the normal stravalib API)
+routes = client.get_routes()
+route_id = routes.next().id
+
+# Get the filename and data stream for the activity data
+data = client.get_route_data(route_id, fmt=DataFormat.GPX)
+
+# Save the activity data to disk using the server-provided filename
+with open(data.filename, 'wb') as f:
+    for chunk in data.content:
+        if not chunk:
+            break
+        f.write(chunk)
+```
+
 
 License
 =======

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except Exception:
 
 setup(
     name="stravaweblib",
-    version="0.0.6",
+    version="0.0.7",
     description="Extends the Strava v3 API using web scraping",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except Exception:
 
 setup(
     name="stravaweblib",
-    version="0.0.7",
+    version="0.0.6",
     description="Extends the Strava v3 API using web scraping",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/stravaweblib/webclient.py
+++ b/stravaweblib/webclient.py
@@ -12,14 +12,14 @@ import requests
 import stravalib
 
 
-__all__ = ["WebClient", "FrameType", "DataFormat", "ActivityFile"]
+__all__ = ["WebClient", "FrameType", "DataFormat", "ExportFile", "ActivityFile"]
 
 
 BASE_URL = "https://www.strava.com"
 
 
-ActivityFile = namedtuple("ActivityFile", ("filename", "content"))
-RouteFile = namedtuple("RouteFile", ("filename", "content"))
+ExportFile = namedtuple("ExportFile", ("filename", "content"))
+ActivityFile = ExportFile  # TODO: deprecate and remove
 
 
 class DataFormat(enum.Enum):
@@ -176,6 +176,31 @@ class WebClient(stravalib.Client):
                 "Failed to delete activity (status code: {})".format(resp.status_code),
             )
 
+    @staticmethod
+    def _make_export_file(resp, id_):
+        # Get file name from request (if possible)
+        content_disposition = resp.headers.get("content-disposition", "")
+        filename = cgi.parse_header(content_disposition)[1].get("filename")
+
+        # Sane default for filename
+        if not filename:
+            filename = str(id_)
+
+        # Note that Strava always removes periods from the filename so if one
+        # exists we know it's for the extension
+        if "." not in filename:
+            if fmt is DataFormat.ORIGINAL:
+                ext = 'dat'
+            else:
+                ext = fmt
+            filename = "{}.{}".format(filename, ext)
+
+        # Return the filename and an iterator to download the file with
+        return ExportFile(
+            filename=filename,
+            content=resp.iter_content(chunk_size=16*1024)  # 16KB
+        )
+
     def get_activity_data(self, activity_id, fmt=DataFormat.ORIGINAL,
                           json_fmt=None):
         """
@@ -201,7 +226,7 @@ class WebClient(stravalib.Client):
         :return: A namedtuple with `filename` and `content` attributes:
                  - `filename` is the filename that Strava suggests for the file
                  - `contents` is an iterator that yields file contents as bytes
-        :rtype: :class:`ActivityFile`
+        :rtype: :class:`ExportFile`
         """
         fmt = DataFormat.classify(fmt)
         url = "{}/activities/{}/export_{}".format(BASE_URL, activity_id, fmt)
@@ -219,26 +244,7 @@ class WebClient(stravalib.Client):
                 raise ValueError("`json_fmt` parameter cannot be DataFormat.ORIGINAL")
             return self.get_activity_data(activity_id, fmt=json_fmt)
 
-        # Get file name from request (if possible)
-        content_disposition = resp.headers.get('content-disposition', "")
-        filename = cgi.parse_header(content_disposition)[1].get('filename')
-
-        # Sane default for filename
-        if not filename:
-            filename = str(activity_id)
-
-        # Note that Strava always removes periods from the filename so if one
-        # exists we know it's for the extension
-        if "." not in filename:
-            if fmt == DataFormat.ORIGINAL:
-                ext = 'dat'
-            else:
-                ext = fmt
-            filename = "{}.{}".format(filename, ext)
-
-        # Return the filename and an iterator to download the file with
-        return ActivityFile(filename=filename,
-                            content=resp.iter_content(chunk_size=16384))
+        return self._make_export_file(resp, activity_id)
 
     def _parse_date(self, date_str):
         if not date_str:
@@ -328,7 +334,7 @@ class WebClient(stravalib.Client):
         else:
             return components
 
-    def get_route_data(self, route_id, fmt: DataFormat = DataFormat.GPX):
+    def get_route_data(self, route_id, fmt=DataFormat.GPX):
         """
         Get a file containing the provided route's data
 
@@ -344,10 +350,9 @@ class WebClient(stravalib.Client):
         :return: A namedtuple with `filename` and `content` attributes:
                  - `filename` is the filename that Strava suggests for the file
                  - `contents` is an iterator that yields file contents as bytes
-        :rtype: :class:`RouteFile`
+        :rtype: :class:`ExportFile`
         """
-        fmt = fmt if fmt != DataFormat.ORIGINAL else DataFormat.GPX  # map "original" -> "gpx"
-        fmt = DataFormat.classify(fmt)
+        fmt = DataFormat.classify(DataFormat.GPX if fmt is DataFormat.ORIGINAL else fmt)
         url = "{}/routes/{}/export_{}".format(BASE_URL, route_id, fmt)
         resp = self._session.get(url, stream=True, allow_redirects=False)
         if resp.status_code != 200:
@@ -355,19 +360,8 @@ class WebClient(stravalib.Client):
                                       "to download a route"
                                       "".format(resp.status_code))
 
-        # Get file name from request (if possible)
-        content_disposition = resp.headers.get('content-disposition', "")
-        filename = cgi.parse_header(content_disposition)[1].get('filename')
+        return self._make_export_file(resp, route_id)
 
-        # Sane default for filename
-        if not filename:
-            filename = str(route_id)
-
-        if "." not in filename:
-            filename += f'.{fmt}'
-
-        # Return the filename and an iterator to download the file with
-        return RouteFile(filename=filename, content=resp.iter_content(chunk_size = 16384))
 
 
 # Inherit parent documentation for WebClient.__init__


### PR DESCRIPTION
Implements a method for downloading route data, similar to activity data downloads.

I've opted to "reuse" the `DataFormat` enum for simplicity.
Since route downloading only supports the formats `gpx` and `tcx`, the `originial` is statically mapped to `gpx`

Closes #11 